### PR TITLE
Add docstrings to Context class and related functions

### DIFF
--- a/src/syngen/ml/context/context.py
+++ b/src/syngen/ml/context/context.py
@@ -3,13 +3,48 @@ import copy
 
 
 class Context:
+    """
+    Manages configuration settings using a dictionary.
+    
+    Attributes
+    ----------
+    config : dict
+        A dictionary to store configuration settings.
+    
+    Methods
+    -------
+    set_config(value: Dict)
+        Sets the configuration dictionary to a deep copy of the provided value.
+    get_config() -> Dict
+        Retrieves the current configuration dictionary.
+    """
+    
     def __init__(self):
+        """
+        Initializes a new instance of the Context class with an empty configuration.
+        """
         self.config = {}
 
     def set_config(self, value: Dict):
+        """
+        Sets the configuration dictionary to a deep copy of the provided value.
+        
+        Parameters
+        ----------
+        value : Dict
+            The configuration dictionary to be set.
+        """
         self.config = copy.deepcopy(value)
 
     def get_config(self) -> Dict:
+        """
+        Retrieves the current configuration dictionary.
+        
+        Returns
+        -------
+        Dict
+            The current configuration dictionary.
+        """
         return self.config
 
 
@@ -18,6 +53,14 @@ _config_instance: Context = None
 
 
 def get_context() -> Context:
+    """
+    Retrieves the singleton instance of the Context class, creating it if necessary.
+    
+    Returns
+    -------
+    Context
+        The singleton instance of the Context class.
+    """
     global _config_instance
     if _config_instance is None:
         _config_instance = Context()
@@ -25,5 +68,13 @@ def get_context() -> Context:
 
 
 def global_context(metadata: Dict):
+    """
+    Sets the global configuration using the provided metadata dictionary.
+    
+    Parameters
+    ----------
+    metadata : Dict
+        The metadata dictionary to set as the global configuration.
+    """
     global_config = get_context()
     global_config.set_config(metadata)


### PR DESCRIPTION
This pull request adds docstrings to the `Context` class, its methods (`__init__`, `set_config`, `get_config`), and the functions `get_context` and `global_context`. These docstrings provide a brief summary of their purpose, parameters, and return types, improving code readability and maintainability.