### PR TITLE
Add docstrings to context module

### DIFF
--- a/src/syngen/ml/context/__init__.py
+++ b/src/syngen/ml/context/__init__.py
@@ -1,1 +1,6 @@
+"""
+This module provides the Context class and associated functions for managing
+configuration contexts in a singleton pattern.
+"""
+
 from syngen.ml.context.context import Context, global_context, get_context  # noqa: F401

--- a/src/syngen/ml/context/context.py
+++ b/src/syngen/ml/context/context.py
@@ -3,13 +3,29 @@ import copy
 
 
 class Context:
+    """
+    A class to manage configuration context using a singleton pattern.
+    """
     def __init__(self):
+        """
+        Initialize the Context with an empty configuration.
+        """
         self.config = {}
 
     def set_config(self, value: Dict):
+        """
+        Set the configuration to a deep copy of the provided value.
+
+        :param value: A dictionary containing configuration settings.
+        """
         self.config = copy.deepcopy(value)
 
     def get_config(self) -> Dict:
+        """
+        Get the current configuration.
+
+        :return: A dictionary containing the current configuration settings.
+        """
         return self.config
 
 
@@ -18,6 +34,11 @@ _config_instance: Context = None
 
 
 def get_context() -> Context:
+    """
+    Retrieve the singleton instance of Context.
+
+    :return: The singleton Context instance.
+    """
     global _config_instance
     if _config_instance is None:
         _config_instance = Context()
@@ -25,5 +46,10 @@ def get_context() -> Context:
 
 
 def global_context(metadata: Dict):
+    """
+    Set the global configuration context with the provided metadata.
+
+    :param metadata: A dictionary containing metadata to set as global configuration.
+    """
     global_config = get_context()
     global_config.set_config(metadata)


### PR DESCRIPTION
This pull request adds detailed docstrings to the `Context` class and its associated functions in the `context.py` file. The docstrings provide explanations for the class, its methods, and the module itself, enhancing code readability and maintainability.