### PR TITLE
Add docstrings to Context class and related functions

### DIFF
--- a/src/syngen/ml/context/context.py
+++ b/src/syngen/ml/context/context.py
@@ -3,13 +3,31 @@ import copy
 
 
 class Context:
+    """
+    A class to manage configuration settings using a singleton pattern.
+    """
     def __init__(self):
+        """
+        Initialize a new Context instance with an empty configuration.
+        """
         self.config = {}
 
     def set_config(self, value: Dict):
+        """
+        Set the configuration to a deep copy of the provided dictionary.
+
+        Args:
+            value (Dict): The configuration dictionary to set.
+        """
         self.config = copy.deepcopy(value)
 
     def get_config(self) -> Dict:
+        """
+        Get the current configuration.
+
+        Returns:
+            Dict: The current configuration dictionary.
+        """
         return self.config
 
 
@@ -18,6 +36,12 @@ _config_instance: Context = None
 
 
 def get_context() -> Context:
+    """
+    Retrieve the singleton instance of Context.
+
+    Returns:
+        Context: The singleton Context instance.
+    """
     global _config_instance
     if _config_instance is None:
         _config_instance = Context()
@@ -25,5 +49,11 @@ def get_context() -> Context:
 
 
 def global_context(metadata: Dict):
+    """
+    Set the global configuration using the provided metadata.
+
+    Args:
+        metadata (Dict): The metadata to set as the global configuration.
+    """
     global_config = get_context()
     global_config.set_config(metadata)


### PR DESCRIPTION
Added docstrings to the Context class and its methods, as well as to the get_context and global_context functions. This improves code readability and provides better understanding of the functionality.